### PR TITLE
Java8だとテストが転けるのを修正

### DIFF
--- a/src/test/java/org/msgpack/rpc/reflect/AnnotationTest.java
+++ b/src/test/java/org/msgpack/rpc/reflect/AnnotationTest.java
@@ -24,7 +24,6 @@ import org.msgpack.rpc.dispatcher.*;
 import org.msgpack.rpc.config.*;
 import org.msgpack.rpc.loop.*;
 import org.msgpack.rpc.loop.netty.*;
-import java.util.*;
 import junit.framework.*;
 import org.junit.Test;
 


### PR DESCRIPTION
Java8でjava.utilにOptionalが追加されたため、

``` java
import org.msgpack.annotation.*;
import java.util.*;
```

このように二つ並べてワイルドカードインポートして、Optionalを使うと干渉する。
実際にはこのテストケース内ではjava.utilのクラスは使われていないようなので削除。
